### PR TITLE
switch from CharacterVector to a string vector

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,12 +6,12 @@
 using namespace Rcpp;
 
 // hash_string
-IntegerVector hash_string(CharacterVector x);
+IntegerVector hash_string(std::vector < std::string > x);
 RcppExport SEXP textreuse_hash_string(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< CharacterVector >::type x(xSEXP);
+    Rcpp::traits::input_parameter< std::vector < std::string > >::type x(xSEXP);
     __result = Rcpp::wrap(hash_string(x));
     return __result;
 END_RCPP

--- a/src/hash_string.cpp
+++ b/src/hash_string.cpp
@@ -10,18 +10,15 @@ using namespace Rcpp;
 //' hash_string(s)
 //' @export
 // [[Rcpp::export]]
-IntegerVector hash_string(CharacterVector x) {
+IntegerVector hash_string(std::vector < std::string > x) {
 
   boost::hash<std::string> hash_fn;
-  int length = x.size();
+  unsigned int length = x.size();
 
   IntegerVector hash_vec(length);
 
-  std::string str;
-
-  for(int i = 0; i < length; i++) {
-    str = Rcpp::as<std::string>(x[i]);
-    hash_vec[i] = hash_fn(str);
+  for(unsigned int i = 0; i < length; i++) {
+    hash_vec[i] = hash_fn(x[i]);
   }
 
   return hash_vec;


### PR DESCRIPTION
This replaces the CharacterVector input for hash_string with a standard string vector. This means you don't need to individually convert elements of x into strings; they're stored that way.